### PR TITLE
🐛  Add missing export

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "types": "dist/types/solid-quill.d.ts",
   "exports": {
     ".": {
+	  "types": "./dist/types/solid-quill.d.ts",
       "solid": "./dist/source/solid-quill.jsx",
       "import": "./dist/esm/solid-quill.js",
       "browser": "./dist/esm/solid-quill.js",


### PR DESCRIPTION
Fix for the following error:

> Could not find a declaration file for module 'solid-quill'. 'my_app/node_modules/solid-quill/dist/esm/solid-quill.js' implicitly has an 'any' type.
> 
> There are types at 'my_app/node_modules/solid-quill/dist/types/solid-quill.d.ts', but this result could not be resolved when respecting package.json "exports". The 'solid-quill' library may need to update its package.json or typings.ts.